### PR TITLE
FIX missing protocol separator in the multilingual cronjob

### DIFF
--- a/cronjobs/generatemultilingual.php
+++ b/cronjobs/generatemultilingual.php
@@ -239,7 +239,7 @@ foreach( $nodeArray as $siteaccessNodeArray )
         /**
          * BC: Site node url alias (calculation)
          */
-        $urlAlias = $sitemapLinkProtocol . $siteURL . $subTreeNode->attribute( 'url_alias' );
+        $urlAlias = $sitemapLinkProtocol . '://' . $siteURL . $subTreeNode->attribute( 'url_alias' );
 
         /**
          * BC: Fetch node's object


### PR DESCRIPTION
Hi,
I'm just fixing a "minor" issue where using multilingual cronjob to generate the sitemap. I just get the code from the other cronjob.

Have a nice day.