### PR TITLE
ends with a single slash no matter what siteurl is

### DIFF
--- a/cronjobs/generate.php
+++ b/cronjobs/generate.php
@@ -161,6 +161,9 @@ foreach ( $siteaccesses as $siteaccess )
      * BC: Fetch siteaccess site url
      */
     $siteURL = $siteaccess['siteurl'];
+    if( substr( $siteURL, -1) != '/' ) {
+        $siteURL .= '/';
+    }
 
     /**
      * Get the Sitemap's root node
@@ -222,7 +225,7 @@ foreach ( $siteaccesses as $siteaccess )
         /**
          * BC: Site node url alias (calculation)
          */
-        $urlAlias = $sitemapLinkProtocol . '://' . $siteURL . '/' . $subTreeNode->attribute( 'url_alias' );
+        $urlAlias = $sitemapLinkProtocol . '://' . $siteURL . $subTreeNode->attribute( 'url_alias' );
 
         /**
          * BC: Fetch node's object

--- a/cronjobs/generatemultilingual.php
+++ b/cronjobs/generatemultilingual.php
@@ -168,6 +168,9 @@ foreach( $siteaccesses as $siteaccess )
      * BC: Fetch siteaccess site url
      */
     $siteURL = $siteaccess['siteurl'];
+    if( substr( $siteURL, -1) != '/' ) {
+        $siteURL .= '/';
+    }
 
     /**
      * Get the Sitemap's root node
@@ -236,7 +239,7 @@ foreach( $nodeArray as $siteaccessNodeArray )
         /**
          * BC: Site node url alias (calculation)
          */
-        $urlAlias = $sitemapLinkProtocol . $siteURL . '/' . $subTreeNode->attribute( 'url_alias' );
+        $urlAlias = $sitemapLinkProtocol . $siteURL . $subTreeNode->attribute( 'url_alias' );
 
         /**
          * BC: Fetch node's object


### PR DESCRIPTION
Hi,
In the case where the siteurl ends with a slash, I get a double slash at the sitemap generation. With this code, I'm sure to get the correct url, no matter what.

Have a nice day and thanks for your work.